### PR TITLE
FPS Counter at the end of the display chain

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -91,6 +91,13 @@ bool EmulatorWindow::Initialize() {
   window_->on_key_down.AddListener([this](KeyEvent* e) {
     bool handled = true;
     switch (e->key_code()) {
+      case 0x48: {  // h
+        if (e->is_shift_pressed()) {
+          window_->FPSTextScale();
+        } else {
+          window_->ToggleFPS();
+        }
+      } break;
       case 0x4F: {  // o
         if (e->is_ctrl_pressed()) {
           FileOpen();

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -48,12 +48,23 @@ class Window {
   virtual void DisableMainMenu() = 0;
 
   const std::wstring& title() const { return title_; }
-  virtual bool set_title(const std::wstring& title) {
+  virtual bool set_title(const std::wstring& title,
+                         bool set_base_title = true) {
     if (title == title_) {
       return false;
     }
     title_ = title;
+    if (set_base_title) {
+      base_title_ = title;
+    }
     return true;
+  }
+
+  void ToggleFPS() { display_fps_ = !display_fps_; }
+
+  void FPSTextScale() {
+    fps_font_scale_ = fps_font_scale_ * 2.0f;
+    fps_font_scale_ = (fps_font_scale_ > 4.0f) ? 1.0f : fps_font_scale_;
   }
 
   virtual bool SetIcon(const void* buffer, size_t size) = 0;
@@ -169,6 +180,7 @@ class Window {
   Loop* loop_ = nullptr;
   std::unique_ptr<MenuItem> main_menu_;
   std::wstring title_;
+  std::wstring base_title_;
   int32_t width_ = 0;
   int32_t height_ = 0;
   bool has_focus_ = true;
@@ -183,6 +195,13 @@ class Window {
   uint64_t fps_update_time_ns_ = 0;
   uint64_t fps_frame_count_ = 0;
   uint64_t last_paint_time_ns_ = 0;
+
+  bool display_fps_ = false;
+  uint32_t game_fps_ = 0;
+  float fps_font_scale_ = 1.0f;
+
+  std::wstring title_fps_text_;
+  std::string osd_fps_text_;
 
   bool modifier_shift_pressed_ = false;
   bool modifier_cntrl_pressed_ = false;

--- a/src/xenia/ui/window_gtk.cc
+++ b/src/xenia/ui/window_gtk.cc
@@ -99,8 +99,8 @@ void GTKWindow::OnClose() {
   super::OnClose();
 }
 
-bool GTKWindow::set_title(const std::wstring& title) {
-  if (!super::set_title(title)) {
+bool GTKWindow::set_title(const std::wstring& title, bool set_base_title) {
+  if (!super::set_title(title, set_base_title)) {
     return false;
   }
   gtk_window_set_title(GTK_WINDOW(window_), (gchar*)title.c_str());

--- a/src/xenia/ui/window_gtk.h
+++ b/src/xenia/ui/window_gtk.h
@@ -35,7 +35,8 @@ class GTKWindow : public Window {
   void EnableMainMenu() override {}
   void DisableMainMenu() override {}
 
-  bool set_title(const std::wstring& title) override;
+  bool set_title(const std::wstring& title,
+                 bool set_base_title = true) override;
 
   bool SetIcon(const void* buffer, size_t size) override;
 

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -193,8 +193,8 @@ void Win32Window::DisableMainMenu() {
   }
 }
 
-bool Win32Window::set_title(const std::wstring& title) {
-  if (!super::set_title(title)) {
+bool Win32Window::set_title(const std::wstring& title, bool set_base_title) {
+  if (!super::set_title(title, set_base_title)) {
     return false;
   }
   SetWindowText(hwnd_, title.c_str());

--- a/src/xenia/ui/window_win.h
+++ b/src/xenia/ui/window_win.h
@@ -33,7 +33,8 @@ class Win32Window : public Window {
   void EnableMainMenu() override;
   void DisableMainMenu() override;
 
-  bool set_title(const std::wstring& title) override;
+  bool set_title(const std::wstring& title,
+                 bool set_base_title = true) override;
 
   bool SetIcon(const void* buffer, size_t size) override;
 


### PR DESCRIPTION
1) Gives actual refresh rate of the window

2) FPS display based on profiler data, toggleable by pressing the the h key
on the keyboard, use Shift + h to modify FPS text scale (x1, x2 or x4)

3) Fix linux build by updating the gtk window

4) Fix linux build again, include microprofiler header directly and correct
parameters sent to ImGui::Text

5) Fix linux build by using a define to hide undefined functions on linux